### PR TITLE
Fixed companies list only showing first 3 companies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>dev.hugog.minecraft</groupId>
   <artifactId>blockstreet</artifactId>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
 
   <properties>
     <maven.compiler.source>11</maven.compiler.source>

--- a/src/main/java/dev/hugog/minecraft/blockstreet/commands/CompaniesCommand.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/commands/CompaniesCommand.java
@@ -50,8 +50,7 @@ public class CompaniesCommand extends BukkitDevCommand {
 		}
 
 		Player player = (Player) getCommandSender();
-
-		List<CompanyDao> companiesList = companiesService.getCompaniesByIdInterval(0, 3);
+		List<CompanyDao> companiesList = companiesService.getAllCompanies();
 
 		player.sendMessage(messages.getPluginHeader());
 		companiesList.forEach(company -> printCompanyDetails(player, messages, company));

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: BlockStreet
 main: dev.hugog.minecraft.blockstreet.BlockStreet
-version: 2.0.0
+version: 2.0.1
 description: This plugin allows you to make investments with your money.
 prefix: 'BlockStreet'
 depend:


### PR DESCRIPTION
### Description:

Implemented a hotfix to ensure the `/invest companies` command displays all available companies. Before this PR, the command would only display the first three companies. I also upgraded the version to 2.0.1.