### PR TITLE
Bugfix: Format high numbers with a more human-readable format.

### DIFF
--- a/src/main/java/dev/hugog/minecraft/blockstreet/BlockStreet.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/BlockStreet.java
@@ -110,7 +110,6 @@ public class BlockStreet extends JavaPlugin {
     }
 
     public void checkForUpdates() {
-
         autoUpdateService.isUpdateAvailable().thenAcceptAsync((isUpdateAvailable) -> {
             if (isUpdateAvailable) {
                 getLogger().warning("An update is available! Download it at: https://www.spigotmc.org/resources/blockstreet.75791/");
@@ -118,7 +117,6 @@ public class BlockStreet extends JavaPlugin {
                 getLogger().info("You are using the latest version of BlockStreet!");
             }
         });
-
     }
 
     private void initializeDevCommands() {

--- a/src/main/java/dev/hugog/minecraft/blockstreet/commands/CompaniesCommand.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/commands/CompaniesCommand.java
@@ -2,6 +2,7 @@ package dev.hugog.minecraft.blockstreet.commands;
 
 import dev.hugog.minecraft.blockstreet.data.dao.CompanyDao;
 import dev.hugog.minecraft.blockstreet.data.services.CompaniesService;
+import dev.hugog.minecraft.blockstreet.utils.FormattingUtils;
 import dev.hugog.minecraft.blockstreet.utils.Messages;
 import dev.hugog.minecraft.dev_command.annotations.AutoValidation;
 import dev.hugog.minecraft.dev_command.annotations.Command;
@@ -67,7 +68,7 @@ public class CompaniesCommand extends BukkitDevCommand {
 		if(currentCompany.getName() != null) {
 			player.sendMessage(ChatColor.GREEN + "" + ChatColor.BOLD + currentCompany.getName());
 			player.sendMessage("");
-			player.sendMessage(ChatColor.GRAY + messages.getPrice() + ": " + ChatColor.GREEN + currentCompany.getFormattedCurrentSharePrice());
+			player.sendMessage(ChatColor.GRAY + messages.getPrice() + ": " + ChatColor.GREEN + FormattingUtils.formatDouble(currentCompany.getCurrentSharePrice()));
 			player.sendMessage(ChatColor.GRAY + messages.getRisk() + ": " + ChatColor.GREEN + currentCompany.getRisk());
 			player.spigot().sendMessage(companyDetails);
 			player.sendMessage("");

--- a/src/main/java/dev/hugog/minecraft/blockstreet/commands/CompanyCommand.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/commands/CompanyCommand.java
@@ -3,18 +3,12 @@ package dev.hugog.minecraft.blockstreet.commands;
 import dev.hugog.minecraft.blockstreet.data.dao.CompanyDao;
 import dev.hugog.minecraft.blockstreet.data.dao.QuoteDao;
 import dev.hugog.minecraft.blockstreet.data.services.CompaniesService;
+import dev.hugog.minecraft.blockstreet.utils.FormattingUtils;
 import dev.hugog.minecraft.blockstreet.utils.Messages;
-import dev.hugog.minecraft.dev_command.annotations.Argument;
-import dev.hugog.minecraft.dev_command.annotations.Arguments;
-import dev.hugog.minecraft.dev_command.annotations.AutoValidation;
-import dev.hugog.minecraft.dev_command.annotations.Command;
-import dev.hugog.minecraft.dev_command.annotations.Dependencies;
+import dev.hugog.minecraft.dev_command.annotations.*;
 import dev.hugog.minecraft.dev_command.arguments.parsers.IntegerArgumentParser;
 import dev.hugog.minecraft.dev_command.commands.BukkitDevCommand;
 import dev.hugog.minecraft.dev_command.commands.data.BukkitCommandData;
-import java.text.DecimalFormat;
-import java.util.List;
-import java.util.stream.Collectors;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.chat.HoverEvent;
@@ -22,6 +16,10 @@ import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+
+import java.text.DecimalFormat;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Company Command
@@ -36,87 +34,87 @@ import org.bukkit.entity.Player;
 @AutoValidation
 @Command(alias = "company", description = "Get details about a company", permission = "blockstreet.command.company", isPlayerOnly = true)
 @Arguments(
-		@Argument(name = "companyId", description = "The ID of the company to get details from.", position = 0, parser = IntegerArgumentParser.class)
+        @Argument(name = "companyId", description = "The ID of the company to get details from.", position = 0, parser = IntegerArgumentParser.class)
 )
-@Dependencies(dependencies = { Messages.class, CompaniesService.class })
+@Dependencies(dependencies = {Messages.class, CompaniesService.class})
 public class CompanyCommand extends BukkitDevCommand {
 
-	public CompanyCommand(BukkitCommandData command, CommandSender commandSender, String[] args) {
-		super(command, commandSender, args);
-	}
+    public CompanyCommand(BukkitCommandData command, CommandSender commandSender, String[] args) {
+        super(command, commandSender, args);
+    }
 
-	@Override
-	public void execute() {
+    @Override
+    public void execute() {
 
-		Messages messages = getDependency(Messages.class);
-		CompaniesService companiesService = getDependency(CompaniesService.class);
-		Player player = (Player) getCommandSender();
+        Messages messages = getDependency(Messages.class);
+        CompaniesService companiesService = getDependency(CompaniesService.class);
+        Player player = (Player) getCommandSender();
 
-		long companyId = Long.parseLong(getArgs()[0]);
-		CompanyDao companyDao = companiesService.getCompanyDaoById(companyId);
+        long companyId = Long.parseLong(getArgs()[0]);
+        CompanyDao companyDao = companiesService.getCompanyDaoById(companyId);
 
-		if (companyDao == null) {
-			player.sendMessage(messages.getPluginPrefix() + messages.getInvalidCompany());
-			return;
-		}
+        if (companyDao == null) {
+            player.sendMessage(messages.getPluginPrefix() + messages.getInvalidCompany());
+            return;
+        }
 
-		printCompanyDetails(companyDao, player, messages);
+        printCompanyDetails(companyDao, player, messages);
 
-	}
+    }
 
-	@Override
-	public List<String> onTabComplete(String[] args) {
-		if (args.length == 1) {
-			CompaniesService companiesService = getDependency(CompaniesService.class);
-			return companiesService.getAllCompanies().stream()
-					.map(CompanyDao::getId)
-					.map(String::valueOf)
-					.collect(Collectors.toList());
-		}
-		return List.of();
-	}
+    @Override
+    public List<String> onTabComplete(String[] args) {
+        if (args.length == 1) {
+            CompaniesService companiesService = getDependency(CompaniesService.class);
+            return companiesService.getAllCompanies().stream()
+                    .map(CompanyDao::getId)
+                    .map(String::valueOf)
+                    .collect(Collectors.toList());
+        }
+        return List.of();
+    }
 
-	private void printCompanyDetails(CompanyDao currentCompany, Player player, Messages messages) {
+    private void printCompanyDetails(CompanyDao currentCompany, Player player, Messages messages) {
 
 
-		TextComponent buyStocks = new TextComponent(ChatColor.GRAY + "[Buy Stocks]");
-		buyStocks.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
-				new ComponentBuilder(ChatColor.GRAY + "Click to see company's details.").create()));
-		buyStocks.setClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/invest buy " + currentCompany.getId() + " 1"));
+        TextComponent buyStocks = new TextComponent(ChatColor.GRAY + "[Buy Stocks]");
+        buyStocks.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
+                new ComponentBuilder(ChatColor.GRAY + "Click to see company's details.").create()));
+        buyStocks.setClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/invest buy " + currentCompany.getId() + " 1"));
 
-		player.sendMessage(messages.getPluginHeader());
-		player.sendMessage("");
-		player.sendMessage(ChatColor.GREEN + "" + ChatColor.BOLD + currentCompany.getName());
-		player.sendMessage("");
-		player.sendMessage(ChatColor.GRAY + "Id: " + ChatColor.GREEN + currentCompany.getId());
-		player.sendMessage(ChatColor.GRAY + messages.getPrice() + ": " + ChatColor.GREEN + currentCompany.getFormattedCurrentSharePrice());
-		player.sendMessage(ChatColor.GRAY + messages.getRisk() + ": " + ChatColor.GREEN + currentCompany.getRisk());
+        player.sendMessage(messages.getPluginHeader());
+        player.sendMessage("");
+        player.sendMessage(ChatColor.GREEN + "" + ChatColor.BOLD + currentCompany.getName());
+        player.sendMessage("");
+        player.sendMessage(ChatColor.GRAY + "Id: " + ChatColor.GREEN + currentCompany.getId());
+        player.sendMessage(ChatColor.GRAY + messages.getPrice() + ": " + ChatColor.GREEN + FormattingUtils.formatDouble(currentCompany.getCurrentSharePrice()));
+        player.sendMessage(ChatColor.GRAY + messages.getRisk() + ": " + ChatColor.GREEN + currentCompany.getRisk());
 
-		if (currentCompany.getAvailableShares() < 0)
-			player.sendMessage(ChatColor.GRAY + messages.getAvailableActions() + ": " + ChatColor.GREEN + "Unlimited");
-		else
-			player.sendMessage(ChatColor.GRAY + messages.getAvailableActions() + ": " + ChatColor.GREEN + currentCompany.getAvailableShares());
+        if (currentCompany.getAvailableShares() < 0)
+            player.sendMessage(ChatColor.GRAY + messages.getAvailableActions() + ": " + ChatColor.GREEN + "Unlimited");
+        else
+            player.sendMessage(ChatColor.GRAY + messages.getAvailableActions() + ": " + ChatColor.GREEN + currentCompany.getAvailableShares());
 
-		player.sendMessage(ChatColor.GRAY + messages.getActionHistoric() + ": ");
-		player.sendMessage("");
+        player.sendMessage(ChatColor.GRAY + messages.getActionHistoric() + ": ");
+        player.sendMessage("");
 
-		List<QuoteDao> quotesToPresent = currentCompany.getHistoric().toList().subList(0, Math.min(5, currentCompany.getHistoric().size()));
-		for (QuoteDao quote : quotesToPresent){
+        List<QuoteDao> quotesToPresent = currentCompany.getHistoric().toList().subList(0, Math.min(5, currentCompany.getHistoric().size()));
+        for (QuoteDao quote : quotesToPresent) {
 
-			DecimalFormat df = new DecimalFormat("###.###%");
+            DecimalFormat df = new DecimalFormat("###.###%");
 
-			if (quote.getVariation() > 0) {
-				player.sendMessage(ChatColor.GREEN + "  +" + df.format(quote.getVariation()));
-			} else {
-				player.sendMessage(ChatColor.RED + "  " + df.format(quote.getVariation()));
-			}
+            if (quote.getVariation() > 0) {
+                player.sendMessage(ChatColor.GREEN + "  +" + df.format(quote.getVariation()));
+            } else {
+                player.sendMessage(ChatColor.RED + "  " + df.format(quote.getVariation()));
+            }
 
-		}
+        }
 
-		player.sendMessage("");
-		player.spigot().sendMessage(buyStocks);
-		player.sendMessage(messages.getPluginFooter());
+        player.sendMessage("");
+        player.spigot().sendMessage(buyStocks);
+        player.sendMessage(messages.getPluginFooter());
 
-	}
+    }
 
 }

--- a/src/main/java/dev/hugog/minecraft/blockstreet/data/dao/CompanyDao.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/data/dao/CompanyDao.java
@@ -24,10 +24,6 @@ public class CompanyDao implements Dao<CompanyEntity> {
     @Setter private int availableShares;
     private SizedStack<QuoteDao> historic;
 
-    public String getFormattedCurrentSharePrice() {
-        return String.format("%.2f", currentSharePrice);
-    }
-
     @Override
     public CompanyEntity toEntity() {
 

--- a/src/main/java/dev/hugog/minecraft/blockstreet/data/services/SignsService.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/data/services/SignsService.java
@@ -6,6 +6,8 @@ import dev.hugog.minecraft.blockstreet.data.dao.SignDao;
 import dev.hugog.minecraft.blockstreet.data.entities.SignEntity;
 import dev.hugog.minecraft.blockstreet.data.repositories.Repository;
 import dev.hugog.minecraft.blockstreet.data.repositories.implementations.SignsRepository;
+import dev.hugog.minecraft.blockstreet.utils.FormattingUtils;
+import dev.hugog.minecraft.blockstreet.utils.VisualizationUtils;
 import lombok.extern.log4j.Log4j2;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -124,10 +126,12 @@ public class SignsService implements Service {
     }
 
     private void updateSign(Sign sign, CompanyDao company) {
+        double lastVariation = !company.getHistoric().isEmpty() ? company.getHistoric().peek().getVariation() : 0.0;
         sign.setLine(0, ChatColor.BOLD + "" + ChatColor.GREEN + "BlockStreet");
         sign.setLine(1, ChatColor.YELLOW + company.getName());
-        sign.setLine(2, ChatColor.GREEN + "Stocks: " + ChatColor.GRAY + company.getFormattedCurrentSharePrice() + "$");
-        sign.setLine(3, ChatColor.GRAY + "Click for details");
+        sign.setLine(2, ChatColor.GREEN + "Value: " + ChatColor.GRAY + FormattingUtils.formatDouble(company.getCurrentSharePrice()));
+        sign.setLine(3, VisualizationUtils.formatCompanyVariation(lastVariation));
+        sign.setEditable(false);
         sign.update();
     }
 

--- a/src/main/java/dev/hugog/minecraft/blockstreet/ui/items/CompanyItem.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/ui/items/CompanyItem.java
@@ -3,6 +3,7 @@ package dev.hugog.minecraft.blockstreet.ui.items;
 import dev.hugog.minecraft.blockstreet.BlockStreet;
 import dev.hugog.minecraft.blockstreet.commands.BuyCommand;
 import dev.hugog.minecraft.blockstreet.data.dao.CompanyDao;
+import dev.hugog.minecraft.blockstreet.utils.FormattingUtils;
 import dev.hugog.minecraft.blockstreet.utils.Messages;
 import dev.hugog.minecraft.blockstreet.utils.VisualizationUtils;
 import dev.hugog.minecraft.dev_command.DevCommand;
@@ -45,8 +46,8 @@ public class CompanyItem extends AbstractItem {
                 .addLoreLines(
                         "",
                         MessageFormat.format(messages.getUiCompanyItemRisk(), company.getRisk()),
-                        MessageFormat.format(messages.getUiCompanyItemSharePrice(), company.getCurrentSharePrice()),
-                        MessageFormat.format(messages.getUiCompanyItemMarketCap(), marketCap),
+                        MessageFormat.format(messages.getUiCompanyItemSharePrice(), FormattingUtils.formatDouble(company.getCurrentSharePrice())),
+                        MessageFormat.format(messages.getUiCompanyItemMarketCap(), FormattingUtils.formatDouble(marketCap)),
                         MessageFormat.format(messages.getUiCompanyItemAllTimeVariation(), VisualizationUtils.formatCompanyVariation(totalVariation)),
                         "",
                         messages.getUiCompanyItemBuyOneShare(),

--- a/src/main/java/dev/hugog/minecraft/blockstreet/ui/items/InvestmentItem.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/ui/items/InvestmentItem.java
@@ -4,6 +4,7 @@ import dev.hugog.minecraft.blockstreet.BlockStreet;
 import dev.hugog.minecraft.blockstreet.commands.SellCommand;
 import dev.hugog.minecraft.blockstreet.data.dao.CompanyDao;
 import dev.hugog.minecraft.blockstreet.data.dao.InvestmentDao;
+import dev.hugog.minecraft.blockstreet.utils.FormattingUtils;
 import dev.hugog.minecraft.blockstreet.utils.Messages;
 import dev.hugog.minecraft.blockstreet.utils.VisualizationUtils;
 import dev.hugog.minecraft.dev_command.DevCommand;
@@ -47,7 +48,7 @@ public class InvestmentItem extends AbstractItem {
                 .addLoreLines(
                         "",
                         MessageFormat.format(messages.getUiInvestmentItemShares(), investment.getSharesAmount()),
-                        MessageFormat.format(messages.getUiInvestmentItemCurrentValue(), currentValue),
+                        MessageFormat.format(messages.getUiInvestmentItemCurrentValue(), FormattingUtils.formatDouble(currentValue)),
                         "",
                         messages.getUiInvestmentItemSellOne(),
                         messages.getUiInvestmentItemSellAll()

--- a/src/main/java/dev/hugog/minecraft/blockstreet/utils/FormattingUtils.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/utils/FormattingUtils.java
@@ -1,0 +1,37 @@
+package dev.hugog.minecraft.blockstreet.utils;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+public final class FormattingUtils {
+
+    /**
+     * Formats a double value into a human-readable string with appropriate units.
+     *
+     * <p>This method formats the given double value into a string representation that follows the following rules:
+     * <ul>
+     *     <li>If the value is less than 1,000, it is formatted with two decimal places (e.g., "123.45").</li>
+     *     <li>If the value is between 1,000 and 999,999, it is divided by 1,000 and suffixed with "K" (e.g., "1.23 K").</li>
+     *     <li>If the value is between 1,000,000 and 999,999,999, it is divided by 1,000,000 and suffixed with "M" (e.g., "1.23 M").</li>
+     *     <li>If the value is between 1,000,000,000 and 999,999,999,999, it is divided by 1,000,000,000 and suffixed with "B" (e.g., "1.23 B").</li>
+     *     <li>If the value is 1,000,000,000,000 or greater, it is divided by 1,000,000,000,000 and suffixed with "T" (e.g., "1.23 T").</li>
+     * </ul>
+     *
+     * @param value the double value to format
+     * @return a formatted string representation of the value
+     */
+    public static String formatDouble(double value) {
+        if (Math.abs(value) < 1_000) {
+            return String.format("%.2f", value);
+        } else if (Math.abs(value) < 1_000_000) {
+            return String.format("%.2f K", value / 1_000);
+        } else if (Math.abs(value) < 1_000_000_000) {
+            return String.format("%.2f M", value / 1_000_000);
+        } else if (Math.abs(value) < 1_000_000_000_000L) {
+            return String.format("%.2f B", value / 1_000_000_000);
+        } else {
+            return String.format("%.2f T", value / 1_000_000_000_000L);
+        }
+    }
+
+}


### PR DESCRIPTION
This PR introduces a new way to format high numbers using a human-readable format:

- `K` is used to represent thousands.
- `M` is used to represent millions.
- `B` is used to represent billions.
- `T` is used to represent trillions.

This format is used especially in places where stock prices are displayed, once these numbers may usually go up in value and end up being too big to be represented by a "regular" number.