### PR TITLE
Bugfix: Players can control admin-created companies

### DIFF
--- a/src/main/java/dev/hugog/minecraft/blockstreet/commands/AdminCreateCommand.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/commands/AdminCreateCommand.java
@@ -49,7 +49,7 @@ public class AdminCreateCommand extends BukkitDevCommand {
         int companySharesAmount = Integer.parseInt(getArgs()[2]);
         double companySharePrice = Double.parseDouble(getArgs()[3]);
 
-        companiesService.createCompany(companyName, companyRisk, companySharesAmount, companySharePrice);
+        companiesService.createAdminCompany(companyName, companyRisk, companySharesAmount, companySharePrice);
         getCommandSender().sendMessage(messages.getPluginPrefix() + MessageFormat.format(messages.getCreatedCompany(), companyName));
 
     }

--- a/src/main/java/dev/hugog/minecraft/blockstreet/commands/CreateCommand.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/commands/CreateCommand.java
@@ -66,7 +66,7 @@ public class CreateCommand extends BukkitDevCommand {
         vaultEconomy.withdrawPlayer(player, companyCreationTax);
 
         // Create the company and move the shares to the player
-        CompanyDao createdCompany = companiesService.createCompany(companyName, companyRisk, companySharesAmount, companySharePrice);
+        CompanyDao createdCompany = companiesService.createPlayerCompany(companyName, companyRisk, companySharesAmount, companySharePrice);
         companiesService.removeSharesFromCompany(createdCompany.getId(), companySharesAmount);
         playersService.addSharesToPlayer(player.getUniqueId(), createdCompany.getId(), companySharesAmount);
 

--- a/src/main/java/dev/hugog/minecraft/blockstreet/data/services/CompaniesService.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/data/services/CompaniesService.java
@@ -38,11 +38,8 @@ public class CompaniesService implements Service {
                 .orElse(null);
     }
 
-    public CompanyDao createCompany(String companyName, int companyRisk, int companyShares, double companySharePrice) {
-        Long companyId = companiesRepository.getNextId();
-
-        CompanyDao newCompany = CompanyDao.builder()
-                .id(companyId.intValue())
+    public CompanyDao createPlayerCompany(String companyName, int companyRisk, int companyShares, double companySharePrice) {
+        return this.createCompany(CompanyDao.builder()
                 .name(companyName)
                 .risk(companyRisk)
                 .totalShares(companyShares)
@@ -50,10 +47,21 @@ public class CompaniesService implements Service {
                 .initialSharePrice(companySharePrice)
                 .currentSharePrice(companySharePrice)
                 .historic(new SizedStack<>(500))
-                .build();
+                .build()
+        );
+    }
 
-        companiesRepository.save(newCompany.toEntity());
-        return newCompany;
+    public CompanyDao createAdminCompany(String companyName, int companyRisk, int companyShares, double companySharePrice) {
+        return this.createCompany(CompanyDao.builder()
+                .name(companyName)
+                .risk(companyRisk)
+                .totalShares(companyShares)
+                .availableShares(companyShares - 1) // Reserve one share for the server, preventing players to assume full control over the company
+                .initialSharePrice(companySharePrice)
+                .currentSharePrice(companySharePrice)
+                .historic(new SizedStack<>(500))
+                .build()
+        );
     }
 
     public CompanyDao createCompany(CompanyDao companyToCreate) {


### PR DESCRIPTION
This PR adds a fix to prevent players from controlling completely admin-created companies. This ensures that players can never delete companies created by admins.