### PR TITLE
Feature: Support for Minecraft 1.21.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>dev.hugog.minecraft</groupId>
   <artifactId>blockstreet</artifactId>
-  <version>2.5.0</version>
+  <version>2.5.1</version>
 
   <properties>
     <maven.compiler.source>11</maven.compiler.source>
@@ -148,7 +148,7 @@
     <dependency>
       <groupId>xyz.xenondevs.invui</groupId>
       <artifactId>invui</artifactId>
-      <version>1.45</version>
+      <version>1.46</version>
       <type>pom</type>
     </dependency>
   </dependencies>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: BlockStreet
 main: dev.hugog.minecraft.blockstreet.BlockStreet
-version: 2.5.0
+version: 2.5.1
 description: This plugin allows you to make investments with your in-game money.
 prefix: 'BlockStreet'
 api-version: 1.16


### PR DESCRIPTION
This PR updates one of the  BlockStreet dependencies to provide support for Minecraft 1.21.6.