### PR TITLE
Bugfix: Company History list inverted

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>dev.hugog.minecraft</groupId>
   <artifactId>blockstreet</artifactId>
-  <version>2.5.2</version>
+  <version>2.5.3</version>
 
   <properties>
     <maven.compiler.source>11</maven.compiler.source>

--- a/src/main/java/dev/hugog/minecraft/blockstreet/commands/CompanyCommand.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/commands/CompanyCommand.java
@@ -1,5 +1,6 @@
 package dev.hugog.minecraft.blockstreet.commands;
 
+import com.google.common.collect.Lists;
 import dev.hugog.minecraft.blockstreet.data.dao.CompanyDao;
 import dev.hugog.minecraft.blockstreet.data.dao.QuoteDao;
 import dev.hugog.minecraft.blockstreet.data.services.CompaniesService;
@@ -99,7 +100,8 @@ public class CompanyCommand extends BukkitDevCommand {
         player.sendMessage(ChatColor.GRAY + messages.getActionHistoric() + ": ");
         player.sendMessage("");
 
-        List<QuoteDao> quotesToPresent = currentCompany.getHistoric().toList().subList(0, Math.min(5, currentCompany.getHistoric().size()));
+        List<QuoteDao> quotesToPresent = Lists.reverse(currentCompany.getHistoric().toList()
+                .subList(Math.max(0, currentCompany.getHistoric().size() - 5), currentCompany.getHistoric().size()));
         for (QuoteDao quote : quotesToPresent) {
 
             DecimalFormat df = new DecimalFormat("###.###%");

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: BlockStreet
 main: dev.hugog.minecraft.blockstreet.BlockStreet
-version: 2.5.2
+version: 2.5.3
 description: This plugin allows you to make investments with your in-game money.
 prefix: 'BlockStreet'
 api-version: 1.16


### PR DESCRIPTION
This PR fixes a bug in which the company's history was inverted, only displaying the first 5 entries since the company was created.