### PR TITLE
Fix: Add original BlockStreet prefix as default value

### DIFF
--- a/src/main/java/dev/hugog/minecraft/blockstreet/utils/Messages.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/utils/Messages.java
@@ -4,7 +4,6 @@ import com.google.inject.Inject;
 import dev.hugog.minecraft.blockstreet.BlockStreet;
 import dev.hugog.minecraft.blockstreet.enums.ConfigurationFiles;
 import lombok.Getter;
-import org.bukkit.ChatColor;
 
 @Getter
 public class Messages {

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -1,8 +1,8 @@
 pluginReload: "Plugin's config successfully reloaded."
 
-pluginPrefix: "BlockStreet"
-pluginHeader: "-=-=-=-=-=-=-=-=-=-= BlockStreet =-=-=-=-=-=-=-=-=-=-"
-pluginFooter: "-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-"
+pluginPrefix: "§a§lBlockStreet §6> §r§7"
+pluginHeader: "§7-=-=-=-=-=-=-=-=-=-= [§aBlockStreet§7] =-=-=-=-=-=-=-=-=-=-"
+pluginFooter: "§7-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-"
 
 menuMainCmd: "Show all plugin's commands."
 menuCompaniesCmd: "List all companies."


### PR DESCRIPTION
Adds the original BlockStreet prefix (with original colors) as the default value in the `messages.yml` file.