### PR TITLE
Bugfix: Remove deleted companies from Player Investments

### DIFF
--- a/src/main/java/dev/hugog/minecraft/blockstreet/commands/AdminDeleteCommand.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/commands/AdminDeleteCommand.java
@@ -2,6 +2,7 @@ package dev.hugog.minecraft.blockstreet.commands;
 
 import dev.hugog.minecraft.blockstreet.data.dao.CompanyDao;
 import dev.hugog.minecraft.blockstreet.data.services.CompaniesService;
+import dev.hugog.minecraft.blockstreet.data.services.PlayersService;
 import dev.hugog.minecraft.blockstreet.utils.Messages;
 import dev.hugog.minecraft.dev_command.annotations.*;
 import dev.hugog.minecraft.dev_command.arguments.parsers.IntegerArgumentParser;
@@ -31,15 +32,16 @@ import java.util.stream.Collectors;
 public class AdminDeleteCommand extends BukkitDevCommand {
 
     private final CompaniesService companiesService;
+    private final PlayersService playersService;
 
     public AdminDeleteCommand(BukkitCommandData commandData, CommandSender commandSender, String[] args) {
         super(commandData, commandSender, args);
         this.companiesService = getDependency(CompaniesService.class);
+        this.playersService = getDependency(PlayersService.class);
     }
 
     @Override
     public void execute() {
-
         Messages messages = getDependency(Messages.class);
         long companyId = Long.parseLong(getArgs()[0]);
 
@@ -50,9 +52,9 @@ public class AdminDeleteCommand extends BukkitDevCommand {
 
         CompanyDao companyToDelete = companiesService.getCompanyById(companyId);
         companiesService.deleteCompany(companyId);
+        playersService.cleanUpInvestmentsForOnlinePlayers(companiesService.getAllCompanies());
 
         getCommandSender().sendMessage(messages.getPluginPrefix() + MessageFormat.format(messages.getDeletedCompany(), companyToDelete.getName()));
-
     }
 
     @Override

--- a/src/main/java/dev/hugog/minecraft/blockstreet/listeners/PlayerJoinListener.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/listeners/PlayerJoinListener.java
@@ -3,6 +3,8 @@ package dev.hugog.minecraft.blockstreet.listeners;
 import com.google.inject.Inject;
 import dev.hugog.minecraft.blockstreet.BlockStreet;
 import dev.hugog.minecraft.blockstreet.api.services.AutoUpdateService;
+import dev.hugog.minecraft.blockstreet.data.services.CompaniesService;
+import dev.hugog.minecraft.blockstreet.data.services.PlayersService;
 import dev.hugog.minecraft.blockstreet.utils.Messages;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -11,34 +13,38 @@ import org.bukkit.event.player.PlayerJoinEvent;
 
 public class PlayerJoinListener implements Listener {
 
-	private final BlockStreet blockStreet;
-	private final Messages messages;
-	private final AutoUpdateService autoUpdateService;
+    private final BlockStreet blockStreet;
+    private final Messages messages;
+    private final AutoUpdateService autoUpdateService;
+    private final PlayersService playersService;
+    private final CompaniesService companiesService;
 
-	@Inject
-	public PlayerJoinListener(BlockStreet blockStreet, Messages messages, AutoUpdateService autoUpdateService) {
-		this.blockStreet = blockStreet;
-		this.messages = messages;
-		this.autoUpdateService = autoUpdateService;
-	}
-	
-	@EventHandler
-	public void onPlayerJoinEvent (PlayerJoinEvent e) {
-		
-		final Player joinedPlayer = e.getPlayer();
+    @Inject
+    public PlayerJoinListener(BlockStreet blockStreet, Messages messages, AutoUpdateService autoUpdateService,
+                              PlayersService playersService, CompaniesService companiesService) {
+        this.blockStreet = blockStreet;
+        this.messages = messages;
+        this.autoUpdateService = autoUpdateService;
+        this.playersService = playersService;
+        this.companiesService = companiesService;
+    }
 
-		if (blockStreet.getConfig().getBoolean("BlockStreet.Updates.Reminder") && (joinedPlayer.isOp() || joinedPlayer.hasPermission("blockstreet.admin.*"))) {
+    @EventHandler
+    public void onPlayerJoinEvent(PlayerJoinEvent e) {
+        Player joinedPlayer = e.getPlayer();
 
-			autoUpdateService.isUpdateAvailable().thenAcceptAsync((isUpdateAvailable) -> {
-				if (isUpdateAvailable) {
-					blockStreet.getServer().getScheduler().runTaskLater(blockStreet, () -> {
-						joinedPlayer.sendMessage(messages.getPluginPrefix() + messages.getNewVersionAvailable());
-					}, 5000);
-				}
-			});
+        if (blockStreet.getConfig().getBoolean("BlockStreet.Updates.Reminder") && (joinedPlayer.isOp() || joinedPlayer.hasPermission("blockstreet.admin.*"))) {
+            autoUpdateService.isUpdateAvailable().thenAcceptAsync((isUpdateAvailable) -> {
+                if (isUpdateAvailable) {
+                    blockStreet.getServer().getScheduler().runTaskLater(blockStreet, () -> {
+                        joinedPlayer.sendMessage(messages.getPluginPrefix() + messages.getNewVersionAvailable());
+                    }, 5000);
+                }
+            });
+        }
 
-		}		
-		
-	}
-	
+        // Clean up investments for the player (remove investments in deleted companies)
+        playersService.cleanUpInvestments(joinedPlayer.getUniqueId(), companiesService.getAllCompanies());
+    }
+
 }


### PR DESCRIPTION
This PR fixes a bug in which deleted companies would still be kept in the player investments, counting for the player's investment limits. 