### PR TITLE
Fix: Profit calculations for investment and portfolio

### DIFF
--- a/src/main/java/dev/hugog/minecraft/blockstreet/data/dao/InvestmentDao.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/data/dao/InvestmentDao.java
@@ -26,7 +26,7 @@ public class InvestmentDao implements Dao<InvestmentEntity> {
      * @return the percentage variation of the investment
      */
     public double getInvestmentVariation(double currentSharePrice) {
-        return 100 - (averageBuyPrice * 100 / currentSharePrice);
+        return (currentSharePrice - averageBuyPrice) / averageBuyPrice * 100;
     }
 
     @Override

--- a/src/main/java/dev/hugog/minecraft/blockstreet/ui/items/PortfolioSummaryItem.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/ui/items/PortfolioSummaryItem.java
@@ -1,6 +1,5 @@
 package dev.hugog.minecraft.blockstreet.ui.items;
 
-import dev.hugog.minecraft.blockstreet.data.dao.CompanyDao;
 import dev.hugog.minecraft.blockstreet.data.dao.InvestmentDao;
 import dev.hugog.minecraft.blockstreet.data.services.CompaniesService;
 import dev.hugog.minecraft.blockstreet.utils.FormattingUtils;
@@ -31,27 +30,20 @@ public class PortfolioSummaryItem extends AutoUpdateItem {
         double totalValue = playerInvestments.stream()
                 .mapToDouble(investment -> investment.getSharesAmount() * companiesService.getCompanyById(investment.getCompanyId()).getCurrentSharePrice())
                 .sum();
-        double averageInvestmentVariation = calculateTotalInvestmentVariation(playerInvestments, totalValue, companiesService);
+        double totalInvestment = playerInvestments.stream()
+                .mapToDouble(investment -> investment.getSharesAmount() * investment.getAverageBuyPrice())
+                .sum();
+        double profitPercentage = (totalValue - totalInvestment) / totalInvestment * 100;
 
         return new ItemBuilder(Material.DARK_OAK_SIGN)
                 .setDisplayName(messages.getUiPortfolioSummaryItemTitle() + MessageFormat.format(messages.getUiCompanyItemLastVariation(),
-                        VisualizationUtils.formatCompanyVariation(averageInvestmentVariation)))
+                        VisualizationUtils.formatCompanyVariation(profitPercentage)))
                 .addLoreLines(
                         "",
                         MessageFormat.format(messages.getUiPortfolioSummaryItemCompanies(), companyCount),
                         MessageFormat.format(messages.getUiPortfolioSummaryItemShares(), totalShares),
                         MessageFormat.format(messages.getUiPortfolioSummaryItemTotalValue(), FormattingUtils.formatDouble(totalValue))
                 );
-    }
-
-    private static double calculateTotalInvestmentVariation(List<InvestmentDao> playerInvestments, double totalPortfolioValue, CompaniesService companiesService) {
-        double totalWeightedVariations = 0d;
-        for (InvestmentDao investment : playerInvestments) {
-            CompanyDao company = companiesService.getCompanyById(investment.getCompanyId());
-            double investmentWeight = (investment.getSharesAmount() * company.getCurrentSharePrice()) / totalPortfolioValue;
-            totalWeightedVariations += investment.getInvestmentVariation(company.getCurrentSharePrice()) * investmentWeight;
-        }
-        return totalWeightedVariations;
     }
 
 }


### PR DESCRIPTION
This PR replaces the formulas used to calculate the profit for each investment and for the overall portfolio. This is required once the old formulas were not working properly. 