### PR TITLE
Feature: Automatic removal of Banrupt companies

### DIFF
--- a/src/main/java/dev/hugog/minecraft/blockstreet/events/CompanyDeleteEvent.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/events/CompanyDeleteEvent.java
@@ -3,16 +3,19 @@ package dev.hugog.minecraft.blockstreet.events;
 import dev.hugog.minecraft.blockstreet.data.dao.CompanyDao;
 import lombok.Getter;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
 @Getter
-@RequiredArgsConstructor
 public class CompanyDeleteEvent extends Event {
     private static final HandlerList handlers = new HandlerList();
 
     private final CompanyDao company;
+
+    public CompanyDeleteEvent(CompanyDao company) {
+        super(true);
+        this.company = company;
+    }
 
     public static HandlerList getHandlerList() {
         return handlers;

--- a/src/main/java/dev/hugog/minecraft/blockstreet/ui/items/InvestmentItem.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/ui/items/InvestmentItem.java
@@ -36,6 +36,10 @@ public class InvestmentItem extends AutoUpdateItem {
     }
 
     public static ItemProvider getItemProvider(Messages messages, CompaniesService companiesService, InvestmentDao investment) {
+        if (!companiesService.companyExists(investment.getCompanyId())) {
+            return new ItemBuilder(Material.AIR);
+        }
+
         CompanyDao company = companiesService.getCompanyById(investment.getCompanyId());
         double currentValue = investment.getSharesAmount() * company.getCurrentSharePrice();
 

--- a/src/main/java/dev/hugog/minecraft/blockstreet/ui/items/PortfolioSummaryItem.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/ui/items/PortfolioSummaryItem.java
@@ -28,6 +28,7 @@ public class PortfolioSummaryItem extends AutoUpdateItem {
                 .mapToInt(InvestmentDao::getSharesAmount)
                 .sum();
         double totalValue = playerInvestments.stream()
+                .filter(investment -> companiesService.companyExists(investment.getCompanyId()))
                 .mapToDouble(investment -> investment.getSharesAmount() * companiesService.getCompanyById(investment.getCompanyId()).getCurrentSharePrice())
                 .sum();
         double totalInvestment = playerInvestments.stream()

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -6,6 +6,7 @@ BlockStreet:
   StockCrash:
     Enabled: true              # Enable or disable stock crashes.
     Aggressiveness: 0.7        # Value between 0 and 1. A higher value means more frequent crashes.
+    RemoveBankrupt: false      # If true, bankrupt companies will automatically be removed from the market.
   Taxes:
     CompanyCreation:           # Tax applied when creating company, applied over the valuation, per risk level
       - 0.1                    # Risk 1 (10% of the total valuation)


### PR DESCRIPTION
This PR adds a new setting to the `config.yml` that allows server admins to configure whether they want the plugin to automatically delete bankrupt companies or not. 