### PR TITLE
Feature: Custoimizable icons for Companies in GUIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
     <dependency>
       <groupId>xyz.xenondevs.invui</groupId>
       <artifactId>invui</artifactId>
-      <version>1.46</version>
+      <version>1.47</version>
       <type>pom</type>
     </dependency>
   </dependencies>

--- a/src/main/java/dev/hugog/minecraft/blockstreet/commands/AdminCreateCommand.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/commands/AdminCreateCommand.java
@@ -1,6 +1,7 @@
 package dev.hugog.minecraft.blockstreet.commands;
 
 import dev.hugog.minecraft.blockstreet.commands.validators.CompanyRiskArgumentParser;
+import dev.hugog.minecraft.blockstreet.commands.validators.MaterialArgumentParser;
 import dev.hugog.minecraft.blockstreet.commands.validators.PositiveIntegerArgumentParser;
 import dev.hugog.minecraft.blockstreet.commands.validators.SharePriceArgumentParser;
 import dev.hugog.minecraft.blockstreet.data.services.CompaniesService;
@@ -9,16 +10,20 @@ import dev.hugog.minecraft.dev_command.annotations.*;
 import dev.hugog.minecraft.dev_command.arguments.parsers.StringArgumentParser;
 import dev.hugog.minecraft.dev_command.commands.BukkitDevCommand;
 import dev.hugog.minecraft.dev_command.commands.data.BukkitCommandData;
+import org.bukkit.Material;
 import org.bukkit.command.CommandSender;
 
 import java.text.MessageFormat;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * Admin Create Company Command
  *
  * <p>Command that allow server administrators to create a new public-domain company.
- * <p>Syntax: /invest admin create [name] [risk] [shares_amount] [share_price]
+ * <p>Syntax: /invest admin create [name] [risk] [shares_amount] [share_price] [icon]
  *
  * @author Hugo1307
  * @since v1.0.0
@@ -30,7 +35,8 @@ import java.util.List;
         @Argument(name = "name", description = "The name of the company to create.", position = 0, parser = StringArgumentParser.class),
         @Argument(name = "risk", description = "The risk of the company to create.", position = 1, parser = CompanyRiskArgumentParser.class),
         @Argument(name = "shares", description = "The amount of shares to create for the company.", position = 2, parser = PositiveIntegerArgumentParser.class),
-        @Argument(name = "price", description = "The price of each share.", position = 3, parser = SharePriceArgumentParser.class)
+        @Argument(name = "price", description = "The price of each share.", position = 3, parser = SharePriceArgumentParser.class),
+        @Argument(name = "icon", description = "The icon of the company (optional).", position = 4, parser = MaterialArgumentParser.class, optional = true)
 })
 public class AdminCreateCommand extends BukkitDevCommand {
 
@@ -48,14 +54,23 @@ public class AdminCreateCommand extends BukkitDevCommand {
         int companyRisk = Integer.parseInt(getArgs()[1]);
         int companySharesAmount = Integer.parseInt(getArgs()[2]);
         double companySharePrice = Double.parseDouble(getArgs()[3]);
+        Material companyIcon = getOptionalArgumentParser(4)
+                .flatMap(parser -> ((MaterialArgumentParser) parser).parse()).orElse(null);
 
-        companiesService.createAdminCompany(companyName, companyRisk, companySharesAmount, companySharePrice);
+        companiesService.createAdminCompany(companyName, companyRisk, companySharesAmount, companySharePrice, companyIcon);
         getCommandSender().sendMessage(messages.getPluginPrefix() + MessageFormat.format(messages.getCreatedCompany(), companyName));
 
     }
 
     @Override
-    public List<String> onTabComplete(String[] strings) {
+    public List<String> onTabComplete(String[] args) {
+        if (args.length == 2) {
+            return IntStream.range(1, 6).mapToObj(String::valueOf).collect(Collectors.toList());
+        } else if (args.length == 5) {
+            return Arrays.stream(Material.values())
+                    .map(Material::toString)
+                    .collect(Collectors.toList());
+        }
         return List.of();
     }
 

--- a/src/main/java/dev/hugog/minecraft/blockstreet/commands/AdminCreateCommand.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/commands/AdminCreateCommand.java
@@ -69,6 +69,7 @@ public class AdminCreateCommand extends BukkitDevCommand {
         } else if (args.length == 5) {
             return Arrays.stream(Material.values())
                     .map(Material::toString)
+                    .filter(name -> name.toLowerCase().startsWith(args[4].toLowerCase()))
                     .collect(Collectors.toList());
         }
         return List.of();

--- a/src/main/java/dev/hugog/minecraft/blockstreet/commands/CreateCommand.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/commands/CreateCommand.java
@@ -1,6 +1,7 @@
 package dev.hugog.minecraft.blockstreet.commands;
 
 import dev.hugog.minecraft.blockstreet.commands.validators.CompanyRiskArgumentParser;
+import dev.hugog.minecraft.blockstreet.commands.validators.MaterialArgumentParser;
 import dev.hugog.minecraft.blockstreet.commands.validators.PositiveIntegerArgumentParser;
 import dev.hugog.minecraft.blockstreet.commands.validators.SharePriceArgumentParser;
 import dev.hugog.minecraft.blockstreet.data.dao.CompanyDao;
@@ -12,17 +13,21 @@ import dev.hugog.minecraft.dev_command.arguments.parsers.StringArgumentParser;
 import dev.hugog.minecraft.dev_command.commands.BukkitDevCommand;
 import dev.hugog.minecraft.dev_command.commands.data.BukkitCommandData;
 import net.milkbowl.vault.economy.Economy;
+import org.bukkit.Material;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 import java.text.MessageFormat;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * Create Company Command
  *
  * <p>Command that allow players to create their own companies.
- * <p>Syntax: /invest company create [name] [risk] [shares_amount] [share_price]
+ * <p>Syntax: /invest company create [name] [risk] [shares_amount] [share_price] [icon]
  *
  * @author Hugo1307
  * @since v1.0.0
@@ -34,7 +39,8 @@ import java.util.List;
         @Argument(name = "name", description = "The name of the company to create.", position = 0, parser = StringArgumentParser.class),
         @Argument(name = "risk", description = "The risk of the company to create.", position = 1, parser = CompanyRiskArgumentParser.class),
         @Argument(name = "shares", description = "The amount of shares to create for the company.", position = 2, parser = PositiveIntegerArgumentParser.class),
-        @Argument(name = "price", description = "The price of each share.", position = 3, parser = SharePriceArgumentParser.class)
+        @Argument(name = "price", description = "The price of each share.", position = 3, parser = SharePriceArgumentParser.class),
+        @Argument(name = "icon", description = "The icon of the company (optional).", position = 4, parser = MaterialArgumentParser.class, optional = true)
 })
 public class CreateCommand extends BukkitDevCommand {
 
@@ -55,6 +61,8 @@ public class CreateCommand extends BukkitDevCommand {
         int companyRisk = Integer.parseInt(getArgs()[1]);
         int companySharesAmount = Integer.parseInt(getArgs()[2]);
         double companySharePrice = Double.parseDouble(getArgs()[3]);
+        Material companyIcon = getOptionalArgumentParser(4)
+                .flatMap(parser -> ((MaterialArgumentParser) parser).parse()).orElse(null);
 
         double companyCreationTax = companiesService.getCompanyCreationTax(companySharesAmount, companySharePrice, companyRisk);
         if (!vaultEconomy.has(player, companyCreationTax)) {
@@ -66,7 +74,7 @@ public class CreateCommand extends BukkitDevCommand {
         vaultEconomy.withdrawPlayer(player, companyCreationTax);
 
         // Create the company and move the shares to the player
-        CompanyDao createdCompany = companiesService.createPlayerCompany(companyName, companyRisk, companySharesAmount, companySharePrice);
+        CompanyDao createdCompany = companiesService.createPlayerCompany(companyName, companyRisk, companySharesAmount, companySharePrice, companyIcon);
         companiesService.removeSharesFromCompany(createdCompany.getId(), companySharesAmount);
         playersService.addSharesToPlayer(player.getUniqueId(), createdCompany, companySharesAmount);
 
@@ -75,7 +83,14 @@ public class CreateCommand extends BukkitDevCommand {
     }
 
     @Override
-    public List<String> onTabComplete(String[] strings) {
+    public List<String> onTabComplete(String[] args) {
+        if (args.length == 2) {
+            return IntStream.range(1, 6).mapToObj(String::valueOf).collect(Collectors.toList());
+        } else if (args.length == 5) {
+            return Arrays.stream(Material.values())
+                    .map(Material::toString)
+                    .collect(Collectors.toList());
+        }
         return List.of();
     }
 }

--- a/src/main/java/dev/hugog/minecraft/blockstreet/commands/CreateCommand.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/commands/CreateCommand.java
@@ -89,6 +89,7 @@ public class CreateCommand extends BukkitDevCommand {
         } else if (args.length == 5) {
             return Arrays.stream(Material.values())
                     .map(Material::toString)
+                    .filter(name -> name.toLowerCase().startsWith(args[4].toLowerCase()))
                     .collect(Collectors.toList());
         }
         return List.of();

--- a/src/main/java/dev/hugog/minecraft/blockstreet/commands/validators/MaterialArgumentParser.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/commands/validators/MaterialArgumentParser.java
@@ -1,0 +1,30 @@
+package dev.hugog.minecraft.blockstreet.commands.validators;
+
+import dev.hugog.minecraft.dev_command.arguments.parsers.CommandArgumentParser;
+import org.bukkit.Material;
+
+import java.util.Optional;
+
+/**
+ * Custom {@link CommandArgumentParser} implementation to match bukkit Materials.
+ */
+public class MaterialArgumentParser extends CommandArgumentParser<Material> {
+
+    public MaterialArgumentParser(String argument) {
+        super(argument);
+    }
+
+    @Override
+    public boolean isValid() {
+        return Material.matchMaterial(this.getArgument()) != null;
+    }
+
+    @Override
+    public Optional<Material> parse() {
+        if (!isValid()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(Material.matchMaterial(this.getArgument()));
+    }
+
+}

--- a/src/main/java/dev/hugog/minecraft/blockstreet/data/dao/CompanyDao.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/data/dao/CompanyDao.java
@@ -3,6 +3,8 @@ package dev.hugog.minecraft.blockstreet.data.dao;
 import dev.hugog.minecraft.blockstreet.data.entities.CompanyEntity;
 import dev.hugog.minecraft.blockstreet.utils.SizedStack;
 import lombok.*;
+import org.bukkit.Material;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.stream.Collectors;
 
@@ -18,6 +20,8 @@ public class CompanyDao implements Dao<CompanyEntity> {
     private int id;
     private String name;
     private String description;
+    @Nullable
+    private Material icon;
     private double initialSharePrice;
     @Setter
     private double currentSharePrice;
@@ -29,12 +33,12 @@ public class CompanyDao implements Dao<CompanyEntity> {
 
     @Override
     public CompanyEntity toEntity() {
-
         CompanyEntity entity = new CompanyEntity();
 
         entity.setId(id);
         entity.setName(name);
         entity.setDescription(description);
+        entity.setIcon(icon);
         entity.setInitialSharePrice(initialSharePrice);
         entity.setCurrentSharePrice(currentSharePrice);
         entity.setRisk(risk);
@@ -43,16 +47,15 @@ public class CompanyDao implements Dao<CompanyEntity> {
         entity.setHistoric(historic.stream().map(Dao::toEntity).collect(Collectors.toList()));
 
         return entity;
-
     }
 
     @Override
     public Dao<CompanyEntity> fromEntity(CompanyEntity entity) {
-
         return new CompanyDao(
                 entity.getId(),
                 entity.getName(),
                 entity.getDescription(),
+                entity.getIcon(),
                 entity.getInitialSharePrice(),
                 entity.getCurrentSharePrice(),
                 entity.getRisk(),
@@ -64,7 +67,6 @@ public class CompanyDao implements Dao<CompanyEntity> {
                                 .collect(Collectors.toList())
                 )
         );
-
     }
 
     public boolean isBankrupt() {

--- a/src/main/java/dev/hugog/minecraft/blockstreet/data/entities/CompanyEntity.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/data/entities/CompanyEntity.java
@@ -1,6 +1,7 @@
 package dev.hugog.minecraft.blockstreet.data.entities;
 
 import lombok.Data;
+import org.bukkit.Material;
 
 import java.util.List;
 
@@ -10,6 +11,7 @@ public class CompanyEntity implements DataEntity {
     private int id;
     private String name;
     private String description;
+    private Material icon;
     private double initialSharePrice;
     private double currentSharePrice;
     private int risk;

--- a/src/main/java/dev/hugog/minecraft/blockstreet/data/services/CompaniesService.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/data/services/CompaniesService.java
@@ -43,10 +43,11 @@ public class CompaniesService implements Service {
                 .orElse(null);
     }
 
-    public CompanyDao createPlayerCompany(String companyName, int companyRisk, int companyShares, double companySharePrice) {
+    public CompanyDao createPlayerCompany(String companyName, int companyRisk, int companyShares, double companySharePrice,
+                                          Material companyIcon) {
         return this.createCompany(CompanyDao.builder()
                 .name(companyName)
-                .icon(Material.EMERALD)
+                .icon(companyIcon)
                 .risk(companyRisk)
                 .totalShares(companyShares)
                 .availableShares(companyShares)
@@ -57,10 +58,11 @@ public class CompaniesService implements Service {
         );
     }
 
-    public CompanyDao createAdminCompany(String companyName, int companyRisk, int companyShares, double companySharePrice) {
+    public CompanyDao createAdminCompany(String companyName, int companyRisk, int companyShares, double companySharePrice,
+                                         Material companyIcon) {
         return this.createCompany(CompanyDao.builder()
                 .name(companyName)
-                .icon(Material.DIAMOND)
+                .icon(companyIcon)
                 .risk(companyRisk)
                 .totalShares(companyShares)
                 .availableShares(companyShares - 1) // Reserve one share for the server, preventing players to assume full control over the company

--- a/src/main/java/dev/hugog/minecraft/blockstreet/data/services/CompaniesService.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/data/services/CompaniesService.java
@@ -10,6 +10,7 @@ import dev.hugog.minecraft.blockstreet.events.CompanyDeleteEvent;
 import dev.hugog.minecraft.blockstreet.events.CompanyStockUpdateEvent;
 import dev.hugog.minecraft.blockstreet.utils.SizedStack;
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
 
 import javax.inject.Inject;
 import java.util.List;
@@ -45,6 +46,7 @@ public class CompaniesService implements Service {
     public CompanyDao createPlayerCompany(String companyName, int companyRisk, int companyShares, double companySharePrice) {
         return this.createCompany(CompanyDao.builder()
                 .name(companyName)
+                .icon(Material.EMERALD)
                 .risk(companyRisk)
                 .totalShares(companyShares)
                 .availableShares(companyShares)
@@ -58,6 +60,7 @@ public class CompaniesService implements Service {
     public CompanyDao createAdminCompany(String companyName, int companyRisk, int companyShares, double companySharePrice) {
         return this.createCompany(CompanyDao.builder()
                 .name(companyName)
+                .icon(Material.DIAMOND)
                 .risk(companyRisk)
                 .totalShares(companyShares)
                 .availableShares(companyShares - 1) // Reserve one share for the server, preventing players to assume full control over the company

--- a/src/main/java/dev/hugog/minecraft/blockstreet/migration/v110/CompaniesMigrator.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/migration/v110/CompaniesMigrator.java
@@ -4,6 +4,7 @@ import dev.hugog.minecraft.blockstreet.data.dao.CompanyDao;
 import dev.hugog.minecraft.blockstreet.data.services.CompaniesService;
 import dev.hugog.minecraft.blockstreet.migration.Migrator;
 import dev.hugog.minecraft.blockstreet.utils.SizedStack;
+import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 
@@ -16,7 +17,7 @@ public class CompaniesMigrator implements Migrator {
     private final File pluginDataDirectory;
     private final CompaniesService companiesService;
 
-    public CompaniesMigrator(File pluginDataDirectory,CompaniesService companiesService) {
+    public CompaniesMigrator(File pluginDataDirectory, CompaniesService companiesService) {
         this.pluginDataDirectory = pluginDataDirectory;
         this.companiesService = companiesService;
     }
@@ -47,6 +48,7 @@ public class CompaniesMigrator implements Migrator {
 
             CompanyDao companyDao = CompanyDao.builder()
                     .name(companyName)
+                    .icon(Material.EMERALD)
                     .risk(risk)
                     .totalShares(sharesAmount)
                     .availableShares(sharesAmount)

--- a/src/main/java/dev/hugog/minecraft/blockstreet/ui/items/CompanyItem.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/ui/items/CompanyItem.java
@@ -39,7 +39,7 @@ public class CompanyItem extends AutoUpdateItem {
         double totalVariation = (company.getCurrentSharePrice() - company.getInitialSharePrice()) / company.getInitialSharePrice() * 100;
         double lastVariation = !company.getHistoric().isEmpty() ? company.getHistoric().peek().getVariation() * 100 : 0;
 
-        return new ItemBuilder(Material.EMERALD)
+        return new ItemBuilder(company.getIcon() != null ? company.getIcon() : Material.EMERALD)
                 .setDisplayName(ChatColor.GOLD + company.getName() + (!company.isBankrupt() ? MessageFormat.format(messages.getUiCompanyItemLastVariation(), VisualizationUtils.formatCompanyVariation(lastVariation)) : ""))
                 .setItemFlags(List.of(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_POTION_EFFECTS))
                 .addLoreLines(

--- a/src/main/java/dev/hugog/minecraft/blockstreet/ui/items/InvestmentItem.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/ui/items/InvestmentItem.java
@@ -43,7 +43,7 @@ public class InvestmentItem extends AutoUpdateItem {
         CompanyDao company = companiesService.getCompanyById(investment.getCompanyId());
         double currentValue = investment.getSharesAmount() * company.getCurrentSharePrice();
 
-        return new ItemBuilder(Material.DIAMOND)
+        return new ItemBuilder(company.getIcon() != null ? company.getIcon() : Material.DIAMOND)
                 .setDisplayName(ChatColor.GOLD + company.getName() + (!company.isBankrupt() ? MessageFormat.format(messages.getUiCompanyItemLastVariation(),
                         VisualizationUtils.formatCompanyVariation(investment.getInvestmentVariation(company.getCurrentSharePrice()))) : ""))
                 .setItemFlags(List.of(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_POTION_EFFECTS))

--- a/src/test/java/dev/hugog/minecraft/blockstreet/commands/validators/MaterialArgumentParserTest.java
+++ b/src/test/java/dev/hugog/minecraft/blockstreet/commands/validators/MaterialArgumentParserTest.java
@@ -1,0 +1,41 @@
+package dev.hugog.minecraft.blockstreet.commands.validators;
+
+import org.bukkit.Material;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MaterialArgumentParserTest {
+
+    @Test
+    void isValid_returnsTrue_forUppercaseMaterial() {
+        MaterialArgumentParser parser = new MaterialArgumentParser("STONE");
+
+        assertTrue(parser.isValid(), "Expected STONE to be a valid material");
+        Optional<Material> parsed = parser.parse();
+        assertTrue(parsed.isPresent());
+        assertEquals(Material.STONE, parsed.get());
+    }
+
+    @Test
+    void isValid_returnsTrue_forLowercaseMaterial() {
+        MaterialArgumentParser parser = new MaterialArgumentParser("stone");
+
+        assertTrue(parser.isValid(), "Expected 'stone' to be a valid material (case-insensitive)");
+        Optional<Material> parsed = parser.parse();
+        assertTrue(parsed.isPresent());
+        assertEquals(Material.STONE, parsed.get());
+    }
+
+    @Test
+    void parse_returnsEmpty_forInvalidMaterial() {
+        MaterialArgumentParser parser = new MaterialArgumentParser("NOT_A_MATERIAL");
+
+        assertFalse(parser.isValid(), "Expected NOT_A_MATERIAL to be invalid");
+        Optional<Material> parsed = parser.parse();
+        assertFalse(parsed.isPresent(), "Expected parse() to return an empty Optional for invalid input");
+    }
+
+}


### PR DESCRIPTION
This pull request adds support for custom company icons in the Blockstreet plugin, allowing both administrators and players to specify a Bukkit `Material` as an icon when creating a company. For existing companies, the icons can be changed through the companies' data files.  