### PR TITLE
feat: Make command arguments translatable

### DIFF
--- a/src/main/java/dev/hugog/minecraft/blockstreet/commands/AdminCreateCommand.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/commands/AdminCreateCommand.java
@@ -29,14 +29,14 @@ import java.util.stream.IntStream;
  * @since v1.0.0
  */
 @AutoValidation
-@Command(alias = "admin create", description = "adminCreateCommandDescription", permission = "blockstreet.admin.command.create")
+@Command(alias = "admin create", description = "adminCreateCommand.description", permission = "blockstreet.admin.command.create")
 @Dependencies(dependencies = {Messages.class, CompaniesService.class})
 @Arguments({
-        @Argument(name = "name", description = "The name of the company to create.", position = 0, parser = StringArgumentParser.class),
-        @Argument(name = "risk", description = "The risk of the company to create.", position = 1, parser = CompanyRiskArgumentParser.class),
-        @Argument(name = "shares", description = "The amount of shares to create for the company.", position = 2, parser = PositiveIntegerArgumentParser.class),
-        @Argument(name = "price", description = "The price of each share.", position = 3, parser = SharePriceArgumentParser.class),
-        @Argument(name = "icon", description = "The icon of the company (optional).", position = 4, parser = MaterialArgumentParser.class, optional = true)
+        @Argument(name = "name", description = "adminCreateCommand.nameArg", position = 0, parser = StringArgumentParser.class),
+        @Argument(name = "risk", description = "adminCreateCommand.riskArg", position = 1, parser = CompanyRiskArgumentParser.class),
+        @Argument(name = "shares", description = "adminCreateCommand.sharesArg", position = 2, parser = PositiveIntegerArgumentParser.class),
+        @Argument(name = "price", description = "adminCreateCommand.priceArg", position = 3, parser = SharePriceArgumentParser.class),
+        @Argument(name = "icon", description = "adminCreateCommand.iconArg", position = 4, parser = MaterialArgumentParser.class, optional = true)
 })
 public class AdminCreateCommand extends BukkitDevCommand {
 

--- a/src/main/java/dev/hugog/minecraft/blockstreet/commands/AdminDeleteCommand.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/commands/AdminDeleteCommand.java
@@ -24,10 +24,10 @@ import java.util.stream.Collectors;
  * @since v1.0.0
  */
 @AutoValidation
-@Command(alias = "admin delete", description = "adminDeleteCommandDescription", permission = "blockstreet.admin.command.delete")
+@Command(alias = "admin delete", description = "adminDeleteCommand.description", permission = "blockstreet.admin.command.delete")
 @Dependencies(dependencies = {Messages.class, CompaniesService.class})
 @Arguments({
-        @Argument(name = "companyId", description = "The ID of the company to delete.", position = 0, parser = IntegerArgumentParser.class)
+        @Argument(name = "companyId", description = "adminDeleteCommand.companyIdArg", position = 0, parser = IntegerArgumentParser.class)
 })
 public class AdminDeleteCommand extends BukkitDevCommand {
 

--- a/src/main/java/dev/hugog/minecraft/blockstreet/commands/BuyCommand.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/commands/BuyCommand.java
@@ -28,11 +28,11 @@ import java.util.stream.Collectors;
  * @since v1.0.0
  */
 @AutoValidation
-@Command(alias = "buy", description = "buyCommandDescription", permission = "blockstreet.command.buy", isPlayerOnly = true)
+@Command(alias = "buy", description = "buyCommand.description", permission = "blockstreet.command.buy", isPlayerOnly = true)
 @Dependencies(dependencies = {Messages.class, Economy.class, CompaniesService.class, PlayersService.class, BlockStreet.class})
 @Arguments({
-        @Argument(name = "companyID", description = "The ID of the company to buy shares from.", position = 0, parser = IntegerArgumentParser.class),
-        @Argument(name = "amount", description = "The amount of shares to buy.", position = 1, parser = PositiveIntegerArgumentParser.class)
+        @Argument(name = "companyID", description = "buyCommand.companyIdArg", position = 0, parser = IntegerArgumentParser.class),
+        @Argument(name = "amount", description = "buyCommand.amountArg", position = 1, parser = PositiveIntegerArgumentParser.class)
 })
 public class BuyCommand extends BukkitDevCommand {
 

--- a/src/main/java/dev/hugog/minecraft/blockstreet/commands/CompaniesCommand.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/commands/CompaniesCommand.java
@@ -30,7 +30,7 @@ import java.util.List;
  * @since v1.0.0
  */
 @AutoValidation
-@Command(alias = "companies", description = "companiesCommandDescription", permission = "blockstreet.command.companies", isPlayerOnly = true)
+@Command(alias = "companies", description = "companiesCommand.description", permission = "blockstreet.command.companies", isPlayerOnly = true)
 @Dependencies(dependencies = {Messages.class, CompaniesService.class})
 public class CompaniesCommand extends BukkitDevCommand {
 

--- a/src/main/java/dev/hugog/minecraft/blockstreet/commands/CompanyCommand.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/commands/CompanyCommand.java
@@ -32,9 +32,9 @@ import java.util.stream.Collectors;
  * @since v1.0.0
  */
 @AutoValidation
-@Command(alias = "company info", description = "companyCommandDescription", permission = "blockstreet.command.company", isPlayerOnly = true)
+@Command(alias = "company info", description = "companyCommand.description", permission = "blockstreet.command.company", isPlayerOnly = true)
 @Arguments(
-        @Argument(name = "companyId", description = "The ID of the company to get details from.", position = 0, parser = IntegerArgumentParser.class)
+        @Argument(name = "companyId", description = "companyCommand.companyIdArg", position = 0, parser = IntegerArgumentParser.class)
 )
 @Dependencies(dependencies = {Messages.class, CompaniesService.class})
 public class CompanyCommand extends BukkitDevCommand {

--- a/src/main/java/dev/hugog/minecraft/blockstreet/commands/CreateCommand.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/commands/CreateCommand.java
@@ -33,14 +33,14 @@ import java.util.stream.IntStream;
  * @since v1.0.0
  */
 @AutoValidation
-@Command(alias = "company create", description = "createCommandDescription", permission = "blockstreet.command.create", isPlayerOnly = true)
+@Command(alias = "company create", description = "createCommand.description", permission = "blockstreet.command.create", isPlayerOnly = true)
 @Dependencies(dependencies = {Messages.class, CompaniesService.class})
 @Arguments({
-        @Argument(name = "name", description = "The name of the company to create.", position = 0, parser = StringArgumentParser.class),
-        @Argument(name = "risk", description = "The risk of the company to create.", position = 1, parser = CompanyRiskArgumentParser.class),
-        @Argument(name = "shares", description = "The amount of shares to create for the company.", position = 2, parser = PositiveIntegerArgumentParser.class),
-        @Argument(name = "price", description = "The price of each share.", position = 3, parser = SharePriceArgumentParser.class),
-        @Argument(name = "icon", description = "The icon of the company (optional).", position = 4, parser = MaterialArgumentParser.class, optional = true)
+        @Argument(name = "name", description = "createCommand.nameArg", position = 0, parser = StringArgumentParser.class),
+        @Argument(name = "risk", description = "createCommand.riskArg", position = 1, parser = CompanyRiskArgumentParser.class),
+        @Argument(name = "shares", description = "createCommand.sharesArg", position = 2, parser = PositiveIntegerArgumentParser.class),
+        @Argument(name = "price", description = "createCommand.priceArg", position = 3, parser = SharePriceArgumentParser.class),
+        @Argument(name = "icon", description = "createCommand.iconArg", position = 4, parser = MaterialArgumentParser.class, optional = true)
 })
 public class CreateCommand extends BukkitDevCommand {
 

--- a/src/main/java/dev/hugog/minecraft/blockstreet/commands/DeleteCommand.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/commands/DeleteCommand.java
@@ -27,10 +27,10 @@ import java.util.stream.Collectors;
  * @since v1.0.0
  */
 @AutoValidation
-@Command(alias = "company delete", description = "deleteCommandDescription", permission = "blockstreet.command.delete", isPlayerOnly = true)
+@Command(alias = "company delete", description = "deleteCommand.description", permission = "blockstreet.command.delete", isPlayerOnly = true)
 @Dependencies(dependencies = {Messages.class, CompaniesService.class})
 @Arguments({
-        @Argument(name = "id", description = "The id of the company to delete.", position = 0, parser = IntegerArgumentParser.class)
+        @Argument(name = "id", description = "deleteCommand.companyIdArg", position = 0, parser = IntegerArgumentParser.class)
 })
 public class DeleteCommand extends BukkitDevCommand {
 

--- a/src/main/java/dev/hugog/minecraft/blockstreet/commands/HelpCommand.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/commands/HelpCommand.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
  * @since v1.0.0
  */
 @AutoValidation
-@Command(alias = "help", description = "helpCommandDescription", permission = "blockstreet.command.help")
+@Command(alias = "help", description = "helpCommand.description", permission = "blockstreet.command.help")
 @Dependencies(dependencies = {BlockStreet.class, Messages.class})
 public class HelpCommand extends BukkitDevCommand {
 
@@ -111,7 +111,7 @@ public class HelpCommand extends BukkitDevCommand {
             } else {
                 argumentComponent = new TextComponent(" <" + commandArgument.name() + ">");
             }
-            argumentComponent.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(commandArgument.description())));
+            argumentComponent.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(messages.getMessageByKey(commandArgument.description()))));
             commandArgumentsBuilder.addExtra(argumentComponent);
         });
         return commandArgumentsBuilder;

--- a/src/main/java/dev/hugog/minecraft/blockstreet/commands/InfoCommand.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/commands/InfoCommand.java
@@ -22,7 +22,7 @@ import java.util.List;
  * @author Hugo1307
  * @version 1.0.0
  */
-@Command(alias = "info", description = "infoCommandDescription", permission = "*", isPlayerOnly = true)
+@Command(alias = "info", description = "infoCommand.description", permission = "*", isPlayerOnly = true)
 @Dependencies(dependencies = {Messages.class, AutoUpdateService.class})
 public class InfoCommand extends BukkitDevCommand {
 

--- a/src/main/java/dev/hugog/minecraft/blockstreet/commands/MainCommand.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/commands/MainCommand.java
@@ -13,7 +13,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 @AutoValidation
-@Command(alias = "", description = "mainCommandDescription", permission = "blockstreet.command.main", isPlayerOnly = true)
+@Command(alias = "", description = "mainCommand.description", permission = "blockstreet.command.main", isPlayerOnly = true)
 @Dependencies(dependencies = {Messages.class})
 @SuppressWarnings("unused")
 public class MainCommand extends BukkitDevCommand {

--- a/src/main/java/dev/hugog/minecraft/blockstreet/commands/PortfolioCommand.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/commands/PortfolioCommand.java
@@ -30,7 +30,7 @@ import java.util.List;
  * @since v1.0.0
  */
 @AutoValidation
-@Command(alias = "portfolio", description = "portfolioCommandDescription", permission = "blockstreet.command.portfolio", isPlayerOnly = true)
+@Command(alias = "portfolio", description = "portfolioCommand.description", permission = "blockstreet.command.portfolio", isPlayerOnly = true)
 @Dependencies(dependencies = {Messages.class, PlayersService.class, CompaniesService.class})
 public class PortfolioCommand extends BukkitDevCommand {
 

--- a/src/main/java/dev/hugog/minecraft/blockstreet/commands/ReloadCommand.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/commands/ReloadCommand.java
@@ -22,7 +22,7 @@ import java.util.List;
  * @since v1.0.0
  */
 @AutoValidation(arguments = false, sender = false)
-@Command(alias = "reload", description = "reloadCommandDescription", permission = "blockstreet.admin.reload")
+@Command(alias = "reload", description = "reloadCommand.description", permission = "blockstreet.admin.reload")
 @Dependencies(dependencies = {Messages.class, BlockStreet.class})
 public class ReloadCommand extends BukkitDevCommand {
 

--- a/src/main/java/dev/hugog/minecraft/blockstreet/commands/SellCommand.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/commands/SellCommand.java
@@ -28,11 +28,11 @@ import java.util.stream.Collectors;
  * @since v1.0.0
  */
 @AutoValidation
-@Command(alias = "sell", description = "sellCommandDescription", permission = "blockstreet.command.sell", isPlayerOnly = true)
+@Command(alias = "sell", description = "sellCommand.description", permission = "blockstreet.command.sell", isPlayerOnly = true)
 @Dependencies(dependencies = {Messages.class, PlayersService.class, CompaniesService.class, Economy.class})
 @Arguments({
-        @Argument(name = "companyID", description = "The ID of the company to sell shares from.", position = 0, parser = IntegerArgumentParser.class),
-        @Argument(name = "amount", description = "The amount of shares to sell.", position = 1, parser = PositiveIntegerArgumentParser.class)
+        @Argument(name = "companyID", description = "sellCommand.companyIdArg", position = 0, parser = IntegerArgumentParser.class),
+        @Argument(name = "amount", description = "sellCommand.amountArg", position = 1, parser = PositiveIntegerArgumentParser.class)
 })
 public class SellCommand extends BukkitDevCommand {
 

--- a/src/main/java/dev/hugog/minecraft/blockstreet/commands/ToggleNotificationCommand.java
+++ b/src/main/java/dev/hugog/minecraft/blockstreet/commands/ToggleNotificationCommand.java
@@ -27,10 +27,10 @@ import java.util.stream.Collectors;
  * @since v2.8.0
  */
 @AutoValidation
-@Command(alias = "notification", description = "toggleNotificationsCommandDescription", permission = "blockstreet.command.notification", isPlayerOnly = true)
+@Command(alias = "notification", description = "toggleNotificationsCommand.description", permission = "blockstreet.command.notification", isPlayerOnly = true)
 @Dependencies(dependencies = {Messages.class, PlayersService.class, CompaniesService.class, Economy.class})
 @Arguments({
-        @Argument(name = "notificationType", description = "The notification type to toggle the value for.", position = 0, parser = NotificationTypeArgumentParser.class),
+        @Argument(name = "notificationType", description = "toggleNotificationsCommand.notificationTypeArg", position = 0, parser = NotificationTypeArgumentParser.class),
 })
 public class ToggleNotificationCommand extends BukkitDevCommand {
 

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -4,21 +4,6 @@ pluginPrefix: "§a§lBlockStreet §6> §r§7"
 pluginHeader: "§7-=-=-=-=-=-=-=-=-=-= [§aBlockStreet§7] =-=-=-=-=-=-=-=-=-=-"
 pluginFooter: "§7-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-"
 
-adminCreateCommandDescription: "Allow admins to create new public company."
-adminDeleteCommandDescription: "Allow admins to delete a public company."
-buyCommandDescription: "Buy company shares."
-companiesCommandDescription: "Check the companies with available shares to sell."
-companyCommandDescription: "Get details about a company."
-createCommandDescription: "Allow players to create new company."
-deleteCommandDescription: "Allow players to delete their company."
-helpCommandDescription: "Show all plugin's commands."
-infoCommandDescription: "Get extra information about the plugin."
-mainCommandDescription: "Opens the plugin main menu."
-portfolioCommandDescription: "Check your investments and shares."
-reloadCommandDescription: "Reloads the plugin."
-sellCommandDescription: "Sell company shares."
-toggleNotificationsCommandDescription: "Toggle stock notifications."
-
 menuMainCmd: "Show all plugin's commands."
 menuCompaniesCmd: "List all companies."
 menuCompanyCmd: "Show details of a company."
@@ -109,3 +94,63 @@ uiNotificationsTitle: "Notification Settings"
 uiNotificationsItemTitle: "§6Notification Settings"
 uiNotificationsItemDescription: "§7Configure your notification preferences"
 uiNotificationsToggleStatus: "§7Status: {0}"
+
+adminCreateCommand:
+  description: "Allow admins to create new public company."
+  nameArg: "The name of the company to create."
+  riskArg: "The risk level of the company."
+  sharesArg: "The amount of shares to create for the company."
+  priceArg: "The price of each share."
+  iconArg: "The icon of the company (optional)."
+
+adminDeleteCommand:
+  description: "Allow admins to delete a public company."
+  companyIdArg: "The Id of the company to delete."
+
+buyCommand:
+  description: "Buy company shares."
+  companyIdArg: "The Id of the company to buy shares from."
+  amountArg: "The amount of shares to buy."
+
+companiesCommand:
+  description: "Check the companies with available shares to sell."
+
+companyCommand:
+  description: "Get details about a company."
+  companyIdArg: "The ID of the company to get details from."
+
+createCommand:
+  description: "Allow players to create new company."
+  nameArg: "The name of the company to create."
+  riskArg: "The risk of the company to create."
+  sharesArg: "The amount of shares to create for the company."
+  priceArg: "The price of each share."
+  iconArg: "The icon of the company (optional)."
+
+deleteCommand:
+  description: "Allow players to delete their company."
+  companyIdArg: "The id of the company to delete."
+
+helpCommand:
+  description: "Show all plugin's commands."
+
+infoCommand:
+  description: "Get extra information about the plugin."
+
+mainCommand:
+  description: "Opens the plugin main menu."
+
+portfolioCommand:
+  description: "Check your investments and shares."
+
+reloadCommand:
+  description: "Reloads the plugin."
+
+sellCommand:
+  description: "Sell company shares."
+  companyIdArg: "The ID of the company to sell shares from."
+  amountArg: "The amount of shares to sell."
+
+toggleNotificationsCommand:
+  description: "Toggle stock notifications."
+  notificationTypeArg: "The notification type to toggle the value for."


### PR DESCRIPTION
This PR refactors how command descriptions and argument help texts are managed for all plugin commands. Instead of hardcoded strings, it now uses message keys that reference entries in the `messages.yml` file, allowing these descriptions to be easily translatable.